### PR TITLE
Fix qr fallback and menu

### DIFF
--- a/handlers/devices.py
+++ b/handlers/devices.py
@@ -4,10 +4,10 @@ from aiogram.fsm.context import FSMContext
 
 from keyboards.main import (
     get_devices_keyboard,
-    get_main_keyboard,
     get_phone_instructions_keyboard,
     get_pc_instructions_keyboard,
 )
+from handlers.start import show_main_menu
 from states.states import MenuState, DeviceState
 from utils.file import create_temp_conf_file
 from utils.qr import create_qr_code
@@ -50,5 +50,4 @@ async def pc_selected(message: types.Message, state: FSMContext) -> None:
 
 @router.message(DeviceState.choose_device, F.text == "⬅️ Назад")
 async def devices_back(message: types.Message, state: FSMContext) -> None:
-    await message.answer("Главное меню", reply_markup=get_main_keyboard())
-    await state.set_state(MenuState.main_menu)
+    await show_main_menu(message, state)

--- a/handlers/faq.py
+++ b/handlers/faq.py
@@ -1,8 +1,8 @@
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 
-from keyboards.main import get_main_keyboard
-from states.states import MenuState, FAQState
+from states.states import FAQState
+from handlers.start import show_main_menu
 
 router = Router()
 
@@ -15,8 +15,7 @@ FAQ_TEXT = (
 )
 
 
-@router.message(MenuState.main_menu, F.text == "❓ Вопросы")
+@router.message(F.text == "❓ Вопросы")
 async def faq_start(message: types.Message, state: FSMContext) -> None:
     await message.answer(FAQ_TEXT)
-    await message.answer("Главное меню", reply_markup=get_main_keyboard())
-    await state.set_state(MenuState.main_menu)
+    await show_main_menu(message, state)

--- a/handlers/referral.py
+++ b/handlers/referral.py
@@ -2,8 +2,9 @@ import logging
 from aiogram import Router, types, F
 from aiogram.fsm.context import FSMContext
 
-from keyboards.main import get_main_keyboard, get_share_keyboard
+from keyboards.main import get_share_keyboard
 from states.states import MenuState, ReferralState
+from handlers.start import show_main_menu
 
 router = Router()
 
@@ -22,5 +23,4 @@ async def referral_start(message: types.Message, state: FSMContext) -> None:
 
 @router.message(ReferralState.waiting_for_share, F.text)
 async def referral_back(message: types.Message, state: FSMContext) -> None:
-    await message.answer("Главное меню", reply_markup=get_main_keyboard())
-    await state.set_state(MenuState.main_menu)
+    await show_main_menu(message, state)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -6,6 +6,8 @@ from aiogram.fsm.context import FSMContext
 from keyboards.main import get_intro_keyboard, get_main_keyboard
 from states.states import MenuState
 
+MAIN_MENU_TEXT = "Вот информация о твоих устройствах и подписке.."
+
 router = Router()
 
 
@@ -28,5 +30,5 @@ async def show_menu_after_intro(message: types.Message, state: FSMContext) -> No
 
 
 async def show_main_menu(message: types.Message, state: FSMContext) -> None:
-    await message.answer("Главное меню", reply_markup=get_main_keyboard())
+    await message.answer(MAIN_MENU_TEXT, reply_markup=get_main_keyboard())
     await state.set_state(MenuState.main_menu)

--- a/handlers/subscription.py
+++ b/handlers/subscription.py
@@ -9,6 +9,7 @@ from keyboards.main import (
     get_subscription_keyboard,
     get_payment_methods_keyboard,
 )
+from handlers.start import show_main_menu
 from states.states import MenuState, SubscriptionState
 
 router = Router()
@@ -56,11 +57,9 @@ async def process_payment(call: types.CallbackQuery, state: FSMContext) -> None:
 
 @router.callback_query(SubscriptionState.payment_method, F.data == "back")
 async def payment_back(call: types.CallbackQuery, state: FSMContext) -> None:
-    await call.message.answer("Главное меню", reply_markup=get_main_keyboard())
-    await state.set_state(MenuState.main_menu)
+    await show_main_menu(call.message, state)
 
 
 @router.message(SubscriptionState.plans, F.text == "⬅️ Назад")
 async def plan_back(message: types.Message, state: FSMContext) -> None:
-    await message.answer("Главное меню", reply_markup=get_main_keyboard())
-    await state.set_state(MenuState.main_menu)
+    await show_main_menu(message, state)

--- a/keyboards/main.py
+++ b/keyboards/main.py
@@ -40,8 +40,12 @@ def get_payment_methods_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
+from urllib.parse import quote_plus
+
+
 def get_share_keyboard(url: str) -> InlineKeyboardMarkup:
-    keyboard = [[InlineKeyboardButton(text="Поделиться ссылкой", url=url)]]
+    share_url = f"https://t.me/share/url?url={quote_plus(url)}"
+    keyboard = [[InlineKeyboardButton(text="Поделиться ссылкой", url=share_url)]]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 

--- a/utils/qr.py
+++ b/utils/qr.py
@@ -1,6 +1,7 @@
 import tempfile
 from pathlib import Path
 from typing import Union
+import base64
 
 try:
     import qrcode
@@ -17,5 +18,9 @@ def create_qr_code(data: str) -> Path:
         img = qrcode.make(data)
         img.save(path)
     else:  # simple fallback
-        path.write_text(data)
+        # provide valid PNG placeholder to avoid Telegram IMAGE_PROCESS_FAILED
+        placeholder = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAHggJ/P/BdVwAAAABJRU5ErkJggg=="
+        )
+        path.write_bytes(placeholder)
     return path


### PR DESCRIPTION
## Summary
- avoid Telegram error when qr library is missing
- unify main menu message and use it when returning back
- use `t.me/share` link for referrals
- allow FAQ access from any menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c335d30e0832e8c277bdf0c910dd4