### PR TITLE
Fix QR code return path

### DIFF
--- a/utils/qr.py
+++ b/utils/qr.py
@@ -29,3 +29,6 @@ def create_qr_code(data: str) -> Path:
         logging.exception("QR generation failed: %s", e)
         placeholder = base64.b64decode(
             "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEElEQVR4nGP4jxcwjEpjAwD6Hirkl4HYkQAAAABJRU5ErkJggg=="
+        )
+        path.write_bytes(placeholder)
+    return path


### PR DESCRIPTION
## Summary
- ensure utils.create_qr_code writes placeholder and returns the path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c44bb37b8832ea3ec3acf55ef4874