### PR TITLE
Add connect device shortcut and update subscription flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+**/__pycache__/

--- a/handlers/devices.py
+++ b/handlers/devices.py
@@ -17,6 +17,12 @@ from vpn.wireguard import generate_peer
 router = Router()
 
 
+@router.callback_query(F.data == "open_devices")
+async def open_devices_cb(call: types.CallbackQuery, state: FSMContext) -> None:
+    await call.answer()
+    await choose_device(call.message, state)
+
+
 @router.message(MenuState.main_menu, F.text == "📱 Устройства")
 async def choose_device(message: types.Message, state: FSMContext) -> None:
     await message.answer("Выберите устройство", reply_markup=get_devices_keyboard())

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -3,7 +3,11 @@ from aiogram import Router, types, F
 from aiogram.filters import CommandStart
 from aiogram.fsm.context import FSMContext
 
-from keyboards.main import get_intro_keyboard, get_main_keyboard
+from keyboards.main import (
+    get_intro_keyboard,
+    get_main_keyboard,
+    get_connect_device_keyboard,
+)
 from states.states import MenuState
 from utils.userdata import build_main_menu_text
 
@@ -31,6 +35,7 @@ async def show_menu_after_intro(message: types.Message, state: FSMContext) -> No
 async def show_main_menu(message: types.Message, state: FSMContext) -> None:
     text = build_main_menu_text(message.from_user.id)
     await message.answer(text, reply_markup=get_main_keyboard(), parse_mode="HTML")
+    await message.answer(" ", reply_markup=get_connect_device_keyboard())
     await state.set_state(MenuState.main_menu)
 
 

--- a/handlers/subscription.py
+++ b/handlers/subscription.py
@@ -16,17 +16,23 @@ router = Router()
 
 
 PLANS = {
-    "1 мес – 99₽": 99_00,
-    "3 мес – 249₽": 249_00,
-    "6 мес – 450₽": 450_00,
+    "1 месяц - 99₽": 99_00,
+    "🔹3 месяца - 249₽": 249_00,
+    "🔸6 месяцев - 450₽": 450_00,
 }
 
 
 @router.message(MenuState.main_menu, F.text == "💎 Подписка")
 async def subscription_plans(message: types.Message, state: FSMContext) -> None:
     text = (
-        "Доступ к VPN после пробного периода.\n"
-        "Выберите тарифный план:"
+        "🔓 Подписка открывает доступ к:\n"
+        "• Стабильному и быстрому соединению\n"
+        "• Доступу к заблокированным сайтам и сервисам\n"
+        "• Одновременному подключению до 3 устройств\n"
+        "• Отсутствие рекламы и прочих отвлекающих вещей\n"
+        "• Самой низкой цене на рынке - всего 3 ₽/день! 🔥\n\n"
+        "Стоимость снижается при оплате за более длительный период. \n\n"
+        "Подключение и оплата — в пару кликов!"
     )
     await message.answer(text, reply_markup=get_subscription_keyboard())
     await state.set_state(SubscriptionState.plans)
@@ -37,12 +43,19 @@ async def _show_payment_options(message: types.Message, state: FSMContext) -> No
     old_msg_id = data.get("payment_message_id")
     if old_msg_id:
         try:
-            await message.bot.delete_message(message.chat.id, old_msg_id)
+            await message.bot.delete_messages(
+                message.chat.id,
+                [old_msg_id],
+                revoke=True,
+            )
         except Exception as e:  # noqa: BLE001
             logging.exception("Failed to delete previous payment message: %s", e)
     await state.update_data(plan=message.text)
     sent = await message.answer(
-        f"Тариф {message.text}. Выберите способ оплаты",
+        "🫶Спасибо за доверие!\n"
+        "Ты на шаг ближе к свободному, безопасному и быстрому интернету — без ограничений.\n"
+        "Мы постарались сделать процесс максимально удобным.\n\n"
+        "👇Выбери подходящий способ оплаты:",
         reply_markup=get_payment_methods_keyboard(),
     )
     await state.update_data(payment_message_id=sent.message_id)

--- a/keyboards/main.py
+++ b/keyboards/main.py
@@ -1,5 +1,9 @@
-from aiogram.types import (ReplyKeyboardMarkup, KeyboardButton,
-                           InlineKeyboardMarkup, InlineKeyboardButton)
+from aiogram.types import (
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
 
 
 def get_intro_keyboard() -> ReplyKeyboardMarkup:
@@ -25,8 +29,8 @@ def get_devices_keyboard() -> ReplyKeyboardMarkup:
 
 def get_subscription_keyboard() -> ReplyKeyboardMarkup:
     keyboard = [
-        [KeyboardButton(text="1 мес – 99₽"), KeyboardButton(text="3 мес – 249₽")],
-        [KeyboardButton(text="6 мес – 450₽")],
+        [KeyboardButton(text="1 месяц - 99₽"), KeyboardButton(text="🔹3 месяца - 249₽")],
+        [KeyboardButton(text="🔸6 месяцев - 450₽")],
         [KeyboardButton(text="⬅️ Назад")],
     ]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
@@ -35,6 +39,13 @@ def get_subscription_keyboard() -> ReplyKeyboardMarkup:
 def get_payment_methods_keyboard() -> InlineKeyboardMarkup:
     keyboard = [
         [InlineKeyboardButton(text="💳 Банковская карта", callback_data="pay_card")],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_connect_device_keyboard() -> InlineKeyboardMarkup:
+    keyboard = [
+        [InlineKeyboardButton(text="🔌 Подключить устройство", callback_data="open_devices")]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 


### PR DESCRIPTION
## Summary
- add inline device connection button
- update subscription texts and tariffs
- use bulk delete with dissolve effect
- ignore Python cache files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c55dbe8dc832e80600eecd4f4f54a