### PR TITLE
Fix empty main menu message

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -37,7 +37,9 @@ async def show_menu_after_intro(message: types.Message, state: FSMContext) -> No
 async def show_main_menu(message: types.Message, state: FSMContext) -> None:
     text = build_main_menu_text(message.from_user.id)
     await message.answer(text, reply_markup=get_main_keyboard(), parse_mode="HTML")
-    await message.answer("\u200b", reply_markup=get_connect_device_keyboard())
+    # Telegram rejects completely empty text messages, including a zero-width
+    # space. Use a non‑breaking space so the text is not stripped.
+    await message.answer("\u00A0", reply_markup=get_connect_device_keyboard())
     await state.set_state(MenuState.main_menu)
 
 


### PR DESCRIPTION
## Summary
- fix zero-width message that caused `text must be non-empty` error

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c5b216208832ebcb681ffaecf8d1e