### PR TITLE
Fix instruction messages and referral text

### DIFF
--- a/handlers/devices.py
+++ b/handlers/devices.py
@@ -85,7 +85,7 @@ async def devices_back(message: types.Message, state: FSMContext) -> None:
 @router.message(F.text == "🔴Инструкция для Android")
 async def android_instructions(message: types.Message) -> None:
     await message.answer(
-        '<a href="https://telegra.ph/Android-Instr-06-25">📱Инструкция для Android</a>',
+        '<a href="https://telegra.ph/Android-Instr-06-25">🔴Инструкция для Android</a>',
         parse_mode="HTML",
     )
 
@@ -93,7 +93,7 @@ async def android_instructions(message: types.Message) -> None:
 @router.message(F.text == "🟢Инструкция для iPhone")
 async def iphone_instructions(message: types.Message) -> None:
     await message.answer(
-        '<a href="https://telegra.ph/Android-Instr-06-25">🍏Инструкция для iPhone</a>',
+        '<a href="https://telegra.ph/Android-Instr-06-25">🟢Инструкция для iPhone</a>',
         parse_mode="HTML",
     )
 

--- a/handlers/referral.py
+++ b/handlers/referral.py
@@ -13,7 +13,11 @@ async def referral_start(message: types.Message, state: FSMContext) -> None:
     bot_username = (await message.bot.get_me()).username
     ref_link = f"https://t.me/{bot_username}?start={message.from_user.id}"
     await message.answer(
-        "Поделитесь ссылкой с другом:",
+        (
+            "🤝 Приглашай друзей — получай дни в подарок.\n\n"
+            "За каждого подключившегося по твоей ссылке — +7 дней к твоей подписке.\n"
+            "Поделись ссылкой и пользуйся дольше — бесплатно."
+        ),
         reply_markup=get_share_keyboard(ref_link),
     )
     logging.info("Referral link sent to %s", message.from_user.id)

--- a/handlers/subscription.py
+++ b/handlers/subscription.py
@@ -43,9 +43,9 @@ async def _show_payment_options(message: types.Message, state: FSMContext) -> No
     old_msg_id = data.get("payment_message_id")
     if old_msg_id:
         try:
-            await message.bot.delete_messages(
-                message.chat.id,
-                [old_msg_id],
+            await message.bot.delete_message(
+                chat_id=message.chat.id,
+                message_id=old_msg_id,
                 revoke=True,
             )
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- delete previous payment messages correctly using `delete_message`
- use correct indicator emoji for Android/iPhone instruction links
- update referral text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c68658454832ebe322e73e53edc35