### PR TITLE
Add hierarchical admin menus

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -2,10 +2,26 @@ import os
 import logging
 from aiogram import Router, types
 from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
 
 from config import config
-from keyboards.admin import get_admin_keyboard
-from utils.storage import ban_user, unban_user, get_user
+from keyboards.admin import (
+    get_admin_main_keyboard,
+    get_admin_panel_keyboard,
+    get_about_keyboard,
+    get_send_keyboard,
+    get_gift_keyboard,
+    get_manage_keyboard,
+)
+from utils.storage import (
+    ban_user,
+    unban_user,
+    get_user,
+    all_user_ids,
+    update_expiration,
+)
+from states.states import AdminState
+from handlers.start import show_main_menu
 
 router = Router()
 
@@ -15,14 +31,15 @@ def _is_admin(user_id: int) -> bool:
 
 
 @router.message(Command("admin"))
-async def admin_start(message: types.Message) -> None:
+async def admin_start(message: types.Message, state: FSMContext) -> None:
     if not _is_admin(message.from_user.id):
         return
     parts = message.text.split(maxsplit=1)
     if len(parts) == 2 and parts[1] == config.admin_key:
         await message.answer(
-            "Админ режим активирован", reply_markup=get_admin_keyboard()
+            "Админ режим активирован", reply_markup=get_admin_main_keyboard()
         )
+        await state.set_state(AdminState.main)
     else:
         await message.answer("Неверный ключ")
 
@@ -64,3 +81,148 @@ async def cmd_devices(message: types.Message) -> None:
         return
     info = get_user(uid)
     await message.answer(str(info))
+
+
+async def _show_admin_main(message: types.Message, state: FSMContext) -> None:
+    await message.answer("Выберите действие:", reply_markup=get_admin_main_keyboard())
+    await state.set_state(AdminState.main)
+
+
+@router.message(AdminState.main, Command("admin_panel"))
+@router.message(AdminState.main, lambda m: m.text == "/admin_panel")
+async def show_panel(message: types.Message, state: FSMContext) -> None:
+    await message.answer("Админ панель", reply_markup=get_admin_panel_keyboard())
+    await state.set_state(AdminState.panel)
+
+
+@router.message(AdminState.main, Command("about"))
+@router.message(AdminState.main, lambda m: m.text == "/about")
+async def show_about(message: types.Message, state: FSMContext) -> None:
+    await message.answer("О боте", reply_markup=get_about_keyboard())
+    await state.set_state(AdminState.about)
+
+
+@router.message(AdminState.main, Command("manage"))
+@router.message(AdminState.main, lambda m: m.text == "/manage")
+async def show_manage(message: types.Message, state: FSMContext) -> None:
+    await message.answer("Управление", reply_markup=get_manage_keyboard())
+    await state.set_state(AdminState.manage)
+
+
+@router.message(AdminState.main, Command("main_menu"))
+@router.message(AdminState.main, lambda m: m.text == "/main_menu")
+async def leave_admin(message: types.Message, state: FSMContext) -> None:
+    await show_main_menu(message, state)
+
+
+@router.message(AdminState.panel, Command("back"))
+@router.message(AdminState.panel, lambda m: m.text == "/back")
+async def panel_back(message: types.Message, state: FSMContext) -> None:
+    await _show_admin_main(message, state)
+
+
+@router.message(AdminState.about, Command("back"))
+@router.message(AdminState.about, lambda m: m.text == "/back")
+async def about_back(message: types.Message, state: FSMContext) -> None:
+    await _show_admin_main(message, state)
+
+
+@router.message(AdminState.manage, Command("back"))
+@router.message(AdminState.manage, lambda m: m.text == "/back")
+async def manage_back(message: types.Message, state: FSMContext) -> None:
+    await _show_admin_main(message, state)
+
+
+@router.message(AdminState.about, Command("send"))
+@router.message(AdminState.about, lambda m: m.text == "/send")
+async def about_send(message: types.Message, state: FSMContext) -> None:
+    await message.answer("Отправить сообщение", reply_markup=get_send_keyboard())
+    await state.set_state(AdminState.send)
+
+
+@router.message(AdminState.about, Command("gift"))
+@router.message(AdminState.about, lambda m: m.text == "/gift")
+async def about_gift(message: types.Message, state: FSMContext) -> None:
+    await message.answer("Выдать подарок", reply_markup=get_gift_keyboard())
+    await state.set_state(AdminState.gift)
+
+
+@router.message(AdminState.send, Command("back"))
+@router.message(AdminState.send, lambda m: m.text == "/back")
+async def send_back(message: types.Message, state: FSMContext) -> None:
+    await about_send.__wrapped__(message, state)  # go back to about menu via function
+
+
+@router.message(AdminState.gift, Command("back"))
+@router.message(AdminState.gift, lambda m: m.text == "/back")
+async def gift_back(message: types.Message, state: FSMContext) -> None:
+    await about_gift.__wrapped__(message, state)
+
+
+@router.message(AdminState.send, Command("to_one"))
+async def send_to_one(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    parts = message.text.split(maxsplit=2)
+    if len(parts) < 3:
+        await message.answer("Usage: /to_one <user_id> <text>")
+        return
+    try:
+        uid = int(parts[1])
+    except Exception:
+        await message.answer("Invalid user id")
+        return
+    await message.bot.send_message(uid, parts[2])
+    await message.answer("Message sent")
+
+
+@router.message(AdminState.send, Command("to_all"))
+async def send_to_all(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Usage: /to_all <text>")
+        return
+    for uid in all_user_ids():
+        try:
+            await message.bot.send_message(uid, parts[1])
+        except Exception:
+            pass
+    await message.answer("Message sent to all users")
+
+
+@router.message(AdminState.gift, Command("to_one"))
+async def gift_to_one(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    parts = message.text.split()
+    if len(parts) != 3:
+        await message.answer("Usage: /to_one <user_id> <minutes>")
+        return
+    try:
+        uid = int(parts[1])
+        mins = int(parts[2])
+    except Exception:
+        await message.answer("Invalid arguments")
+        return
+    update_expiration(uid, mins)
+    await message.answer("Gift applied")
+
+
+@router.message(AdminState.gift, Command("to_all"))
+async def gift_to_all(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    parts = message.text.split(maxsplit=1)
+    if len(parts) != 2:
+        await message.answer("Usage: /to_all <minutes>")
+        return
+    try:
+        mins = int(parts[1])
+    except Exception:
+        await message.answer("Invalid minutes")
+        return
+    for uid in all_user_ids():
+        update_expiration(uid, mins)
+    await message.answer("Gift applied to all users")

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -1,10 +1,56 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 
-def get_admin_keyboard() -> ReplyKeyboardMarkup:
+def get_admin_main_keyboard() -> ReplyKeyboardMarkup:
     keyboard = [
-        [KeyboardButton(text="/stats"), KeyboardButton(text="/peers")],
-        [KeyboardButton(text="/traffic"), KeyboardButton(text="/sysinfo")],
+        [KeyboardButton(text="/admin_panel")],
+        [KeyboardButton(text="/about")],
+        [KeyboardButton(text="/manage")],
+        [KeyboardButton(text="/main_menu")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_admin_panel_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text="/stats")],
+        [KeyboardButton(text="/peers")],
+        [KeyboardButton(text="/traffic")],
+        [KeyboardButton(text="/sysinfo")],
         [KeyboardButton(text="/restart_wg")],
+        [KeyboardButton(text="/back")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_about_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text="/send")],
+        [KeyboardButton(text="/gift")],
+        [KeyboardButton(text="/back")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_send_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text="/to_one"), KeyboardButton(text="/to_all")],
+        [KeyboardButton(text="/back")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_gift_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text="/to_one"), KeyboardButton(text="/to_all")],
+        [KeyboardButton(text="/back")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_manage_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text="/ban"), KeyboardButton(text="/unban")],
+        [KeyboardButton(text="/back")],
     ]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)

--- a/states/states.py
+++ b/states/states.py
@@ -18,3 +18,12 @@ class SubscriptionState(StatesGroup):
 
 class FAQState(StatesGroup):
     reading = State()
+
+
+class AdminState(StatesGroup):
+    main = State()
+    panel = State()
+    about = State()
+    send = State()
+    gift = State()
+    manage = State()

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -80,3 +80,9 @@ def update_expiration(user_id: int, minutes: int) -> None:
     info = get_user(user_id)
     info["expires_at"] = datetime.utcnow() + timedelta(minutes=minutes)
     save_user(user_id, info)
+
+
+def all_user_ids() -> list[int]:
+    """Return list of all known user IDs."""
+    data = _load()
+    return [int(uid) for uid in data.keys()]


### PR DESCRIPTION
## Summary
- restructure admin keyboard into a hierarchy
- add new `AdminState` FSM states
- implement submenus for admin panel, about, and manage
- support sending messages and gifts to one or all users
- expose helper `all_user_ids()`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efe457794832eae4439e4cf26482b