### PR TITLE
Fix /back handling in admin send/gift

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -150,13 +150,15 @@ async def about_gift(message: types.Message, state: FSMContext) -> None:
 @router.message(AdminState.send, Command("back"))
 @router.message(AdminState.send, lambda m: m.text == "/back")
 async def send_back(message: types.Message, state: FSMContext) -> None:
-    await about_send.__wrapped__(message, state)  # go back to about menu via function
+    # Return to the "about" menu when leaving the sending section
+    await show_about(message, state)
 
 
 @router.message(AdminState.gift, Command("back"))
 @router.message(AdminState.gift, lambda m: m.text == "/back")
 async def gift_back(message: types.Message, state: FSMContext) -> None:
-    await about_gift.__wrapped__(message, state)
+    # Return to the "about" menu when leaving the gifting section
+    await show_about(message, state)
 
 
 @router.message(AdminState.send, Command("to_one"))


### PR DESCRIPTION
## Summary
- fix `/back` usage after sending or gifting
- ensure return from these states goes to the about menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f021bac04832ebba78914ccbe4683