### PR TITLE
Fix admin messaging and broadcasts

### DIFF
--- a/utils/userdata.py
+++ b/utils/userdata.py
@@ -21,8 +21,10 @@ def mark_device_connected(user_id: int, device: str, config: str) -> None:
 
 
 def get_user_info(user_id: int) -> Dict[str, Any]:
-    """Return stored info for user."""
-    return get_user(user_id)
+    """Return stored info for user and ensure it is stored."""
+    info = get_user(user_id)
+    save_user(user_id, info)
+    return info
 
 
 def plural(value: int, forms: tuple[str, str, str]) -> str:


### PR DESCRIPTION
## Summary
- fix line breaks in sysinfo message
- reorganize about text layout
- send broadcasts using stored users and streamline gift-all handler
- clarify admin feedback when delivering configs

## Testing
- `python -m py_compile admin.py utils/userdata.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8bbecb950832eb59fb86ce8e03168