### PR TITLE
Fix gift to all confirmation buttons

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -401,7 +401,7 @@ async def _gift(user_id: int, hours: int) -> dt.datetime:
     return new_exp
 
 
-@router.callback_query(lambda c: c.data.startswith("gift"))
+@router.callback_query(lambda c: c.data.startswith("gift:"))
 @admin_only_callback
 async def cb_gift(callback: types.CallbackQuery, state: FSMContext) -> None:
     if callback.data == "gift:menu":


### PR DESCRIPTION
## Summary
- Avoid mismatching gift callback handlers so gift to all confirmations reach the correct handler

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6f4a21f0c832eac31dcf8ae0fd01a