### PR TITLE
Ensure Windows selector loop and open async pool

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 from aiogram import Bot, Dispatcher
@@ -28,4 +29,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    if os.name == "nt":
+        # psycopg async не дружит с ProactorEventLoop
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(main())

--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 # db.py
 import os
-import psycopg
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
@@ -34,11 +33,12 @@ async def init_pool(min_size: int = 1, max_size: int = 10) -> None:
         min_size=min_size,
         max_size=max_size,
         kwargs={
+            "row_factory": dict_row,
             "autocommit": False,
-            "row_factory": dict_row,  # строки как dict
-            "prepare_threshold": 0,   # безопасно для пулов
+            "prepare_threshold": 0,
         },
     )
+    await pool.open()
 
 
 async def close_pool() -> None:


### PR DESCRIPTION
## Summary
- ensure the bot uses the Windows selector event loop policy before startup
- open the async PostgreSQL pool during initialization to avoid lazy connection issues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d593ee8c80832e8ce3a6998577cd10