### PR TITLE
Initialize PostgreSQL schema on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,12 +6,13 @@ from aiogram import Bot, Dispatcher
 from config import config
 from handlers import start, devices, subscription, referral, faq
 from admin import router as admin_router
-from db import close_pool, init_pool, ping
+from db import close_pool, init_pool, init_schema, ping
 
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     await init_pool()
+    await init_schema()
     assert await ping(), "DB ping failed"
     bot = Bot(token=config.bot_token)
     dp = Dispatcher()

--- a/db.py
+++ b/db.py
@@ -21,6 +21,80 @@ POSTGRES_DSN = os.getenv(
 pool: AsyncConnectionPool | None = None
 
 
+async def init_schema() -> None:
+    """Ensure required tables and indexes exist."""
+    if pool is None:
+        raise RuntimeError("DB pool is not initialized. Call init_pool() first.")
+
+    statements = [
+        """
+        CREATE TABLE IF NOT EXISTS users (
+          id            BIGSERIAL PRIMARY KEY,
+          tg_user_id    BIGINT UNIQUE NOT NULL,
+          joined_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          last_seen_at  TIMESTAMPTZ,
+          locale        TEXT DEFAULT 'ru',
+          is_banned     BOOLEAN NOT NULL DEFAULT FALSE,
+          ref_code      TEXT UNIQUE,
+          referred_by   TEXT,
+          device_limit  INT
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS subscriptions (
+          id         BIGSERIAL PRIMARY KEY,
+          user_id    BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          plan       TEXT NOT NULL,
+          status     TEXT NOT NULL,
+          started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          expires_at TIMESTAMPTZ NOT NULL,
+          source     TEXT
+        );
+        """,
+        "CREATE INDEX IF NOT EXISTS ix_sub_user ON subscriptions(user_id);",
+        "CREATE INDEX IF NOT EXISTS ix_sub_active ON subscriptions(user_id,status,expires_at);",
+        """
+        CREATE TABLE IF NOT EXISTS devices (
+          id                BIGSERIAL PRIMARY KEY,
+          user_id           BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          label             TEXT,
+          platform          TEXT,
+          type              TEXT,
+          config_id         TEXT,
+          public_key        TEXT,
+          created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          revoked_at        TIMESTAMPTZ,
+          status            TEXT NOT NULL DEFAULT 'active',
+          last_handshake_at TIMESTAMPTZ,
+          bytes_up          BIGINT NOT NULL DEFAULT 0,
+          bytes_down        BIGINT NOT NULL DEFAULT 0
+        );
+        """,
+        "CREATE INDEX IF NOT EXISTS ix_dev_user ON devices(user_id);",
+        "CREATE INDEX IF NOT EXISTS ix_dev_active ON devices(user_id,status);",
+        """
+        CREATE TABLE IF NOT EXISTS traffic_daily (
+          id         BIGSERIAL PRIMARY KEY,
+          user_id    BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          device_id  BIGINT REFERENCES devices(id) ON DELETE SET NULL,
+          date       DATE NOT NULL,
+          bytes_up   BIGINT NOT NULL DEFAULT 0,
+          bytes_down BIGINT NOT NULL DEFAULT 0,
+          UNIQUE(user_id, device_id, date)
+        );
+        """,
+        "CREATE INDEX IF NOT EXISTS ix_traffic_date ON traffic_daily(date);",
+    ]
+
+    async with pool.connection() as ac:
+        async with ac.cursor() as cur:
+            for statement in statements:
+                await cur.execute(statement)
+        await ac.commit()
+
+    print("✅ Schema initialized")
+
+
 async def init_pool(min_size: int = 1, max_size: int = 10) -> None:
     """
     Инициализация пула соединений. Вызывать один раз при старте бота.


### PR DESCRIPTION
## Summary
- add async init_schema helper that creates required PostgreSQL tables and indexes if missing
- initialize the schema during bot startup after the connection pool is opened

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d59fa0efdc832eb17ee78d1a716640