### PR TITLE
Store runtime data in PostgreSQL

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -11,7 +11,7 @@ import psutil
 from config import config
 from db import execute, fetchall, fetchone
 from settings import VERSION, TARIFFS, LIMITS
-from utils.storage import all_user_ids, is_banned
+from utils.storage import all_user_ids
 
 router = Router()
 
@@ -362,7 +362,7 @@ async def send_to_one_text(message: types.Message, state: FSMContext) -> None:
 @admin_only
 async def send_to_all_text(message: types.Message, state: FSMContext) -> None:
     text = message.text
-    ids = [uid for uid in all_user_ids() if not is_banned(uid)]
+    ids = await all_user_ids(banned=False)
     sent = failed = 0
     for uid in ids:
         if await _send_to_one(message.bot, uid, text):
@@ -494,7 +494,7 @@ async def cb_gift_all(callback: types.CallbackQuery, state: FSMContext) -> None:
         return
     data = await state.get_data()
     hours = data.get("hours", 0)
-    ids = all_user_ids()
+    ids = await all_user_ids()
     applied = 0
     for uid in ids:
         await _gift(uid, hours)
@@ -582,7 +582,7 @@ async def cmd_send_to_all(message: types.Message) -> None:
     if not text:
         await message.answer("❌ Ошибка: нет текста")
         return
-    ids = [uid for uid in all_user_ids() if not is_banned(uid)]
+    ids = await all_user_ids(banned=False)
     sent = failed = 0
     for uid in ids:
         if await _send_to_one(message.bot, uid, text):

--- a/handlers/devices.py
+++ b/handlers/devices.py
@@ -35,10 +35,10 @@ async def choose_device(message: types.Message, state: FSMContext) -> None:
 
 @router.message(DeviceState.choose_device, F.text == "📱Телефон")
 async def phone_selected(message: types.Message, state: FSMContext) -> None:
-    if peers_count(message.from_user.id) >= 5:
+    if await peers_count(message.from_user.id) >= 5:
         await message.answer(t("devices_limit_reached"))
         return
-    config = generate_peer(message.from_user.id)
+    config = await generate_peer(message.from_user.id)
     conf_file = create_temp_conf_file(config)
     qr_file = create_qr_code(config)
     await message.answer_photo(
@@ -50,17 +50,17 @@ async def phone_selected(message: types.Message, state: FSMContext) -> None:
         t("devices_pick_guide"),
         reply_markup=get_phone_instructions_keyboard(),
     )
-    mark_device_connected(message.from_user.id, "📱Телефон", config)
+    await mark_device_connected(message.from_user.id, "📱Телефон", config)
     logging.info("Sent phone config to %s", message.from_user.id)
     await state.set_state(DeviceState.choose_device)
 
 
 @router.message(DeviceState.choose_device, F.text == "💻Компьютер")
 async def pc_selected(message: types.Message, state: FSMContext) -> None:
-    if peers_count(message.from_user.id) >= 5:
+    if await peers_count(message.from_user.id) >= 5:
         await message.answer(t("devices_limit_reached"))
         return
-    config = generate_peer(message.from_user.id)
+    config = await generate_peer(message.from_user.id)
     conf_file = create_temp_conf_file(config)
     qr_file = create_qr_code(config)
     await message.answer_photo(
@@ -72,14 +72,14 @@ async def pc_selected(message: types.Message, state: FSMContext) -> None:
         t("devices_pick_guide"),
         reply_markup=get_pc_instructions_keyboard(),
     )
-    mark_device_connected(message.from_user.id, "💻Компьютер", config)
+    await mark_device_connected(message.from_user.id, "💻Компьютер", config)
     logging.info("Sent PC config to %s", message.from_user.id)
     await state.set_state(DeviceState.choose_device)
 
 
 @router.message(DeviceState.choose_device, F.text == "Мои устройства")
 async def my_devices(message: types.Message, state: FSMContext) -> None:
-    info = get_user_info(message.from_user.id)
+    info = await get_user_info(message.from_user.id)
     devices = list(info.get("devices", {}).keys())
     if not devices:
         await message.answer(t("devices_none"), reply_markup=get_devices_keyboard())
@@ -100,7 +100,7 @@ async def my_devices_back(message: types.Message, state: FSMContext) -> None:
 
 @router.message(DeviceState.my_devices)
 async def resend_config(message: types.Message, state: FSMContext) -> None:
-    info = get_user_info(message.from_user.id)
+    info = await get_user_info(message.from_user.id)
     device = info.get("devices", {}).get(message.text)
     if not device:
         await message.answer(

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -36,7 +36,7 @@ async def show_menu_after_intro(message: types.Message, state: FSMContext) -> No
 
 
 async def show_main_menu(message: types.Message, state: FSMContext) -> None:
-    info = get_user_info(message.from_user.id)
+    info = await get_user_info(message.from_user.id)
     devices = info.get("devices", {})
     expires = info.get("expires_at")
     time_left = (expires - datetime.utcnow()) if expires else timedelta()

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,87 +1,175 @@
-import json
-from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Any, Dict
+"""Helpers for storing bot data in PostgreSQL."""
 
-USERS_FILE = Path("users.json")
+from __future__ import annotations
 
+import datetime as dt
+from typing import Any, Dict, List
 
-def _load() -> Dict[str, Any]:
-    try:
-        with USERS_FILE.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        for info in data.values():
-            if info.get("expires_at"):
-                info["expires_at"] = datetime.fromisoformat(info["expires_at"])
-        return data
-    except Exception:
-        return {}
+from db import execute, fetchall, fetchone
 
 
-def _save(data: Dict[str, Any]) -> None:
-    serializable = {}
-    for uid, info in data.items():
-        ser = info.copy()
-        if ser.get("expires_at"):
-            ser["expires_at"] = ser["expires_at"].isoformat()
-        serializable[uid] = ser
-    with USERS_FILE.open("w", encoding="utf-8") as f:
-        json.dump(serializable, f, ensure_ascii=False, indent=2)
+async def _ensure_user_record(tg_user_id: int) -> int:
+    """Return internal DB id for Telegram user, creating the record if needed."""
 
+    row = await fetchone("SELECT id FROM users WHERE tg_user_id=%s", tg_user_id)
+    if row:
+        return row["id"]
 
-def get_user(user_id: int) -> Dict[str, Any]:
-    data = _load()
-    uid = str(user_id)
-    return data.get(
-        uid,
-        {
-            "devices": {},
-            "expires_at": None,
-            "peers": 0,
-            "banned": False,
-        },
+    await execute(
+        "INSERT INTO users (tg_user_id) VALUES (%s) ON CONFLICT (tg_user_id) DO NOTHING",
+        tg_user_id,
     )
 
-
-def save_user(user_id: int, info: Dict[str, Any]) -> None:
-    data = _load()
-    data[str(user_id)] = info
-    _save(data)
-
-
-def increment_peers(user_id: int) -> None:
-    info = get_user(user_id)
-    info["peers"] = info.get("peers", 0) + 1
-    save_user(user_id, info)
+    row = await fetchone("SELECT id FROM users WHERE tg_user_id=%s", tg_user_id)
+    if not row:
+        raise RuntimeError("Failed to ensure users record")
+    return row["id"]
 
 
-def peers_count(user_id: int) -> int:
-    return get_user(user_id).get("peers", 0)
+async def touch_user(tg_user_id: int) -> None:
+    """Update last seen timestamp for the user."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+    await execute("UPDATE users SET last_seen_at=NOW() WHERE id=%s", user_id)
 
 
-def ban_user(user_id: int) -> None:
-    info = get_user(user_id)
-    info["banned"] = True
-    save_user(user_id, info)
+async def get_user(tg_user_id: int) -> Dict[str, Any]:
+    """Fetch aggregated user info used across the bot."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+
+    user_row = await fetchone("SELECT is_banned FROM users WHERE id=%s", user_id)
+
+    devices_rows = await fetchall(
+        """
+        SELECT label, config_id
+        FROM devices
+        WHERE user_id=%s AND status='active'
+        ORDER BY created_at
+        """,
+        user_id,
+    )
+
+    devices: Dict[str, Dict[str, str]] = {}
+    for idx, row in enumerate(devices_rows, start=1):
+        label = row.get("label") or f"Устройство {idx}"
+        devices[label] = {"config": row.get("config_id") or ""}
+
+    sub_row = await fetchone(
+        """
+        SELECT id, expires_at
+        FROM subscriptions
+        WHERE user_id=%s AND status='active'
+        ORDER BY expires_at DESC
+        LIMIT 1
+        """,
+        user_id,
+    )
+
+    expires_at = None
+    if sub_row and sub_row.get("expires_at"):
+        expires_at = sub_row["expires_at"]
+        if expires_at.tzinfo is not None:
+            expires_at = expires_at.astimezone(dt.timezone.utc).replace(tzinfo=None)
+
+    return {
+        "devices": devices,
+        "expires_at": expires_at,
+        "peers": len(devices_rows),
+        "banned": bool(user_row and user_row.get("is_banned")),
+    }
 
 
-def unban_user(user_id: int) -> None:
-    info = get_user(user_id)
-    info["banned"] = False
-    save_user(user_id, info)
+async def save_device_config(tg_user_id: int, label: str, config: str) -> None:
+    """Store or update WireGuard config for the device."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+    row = await fetchone(
+        """
+        SELECT id
+        FROM devices
+        WHERE user_id=%s AND label=%s AND status='active'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        user_id,
+        label,
+    )
+
+    if row:
+        await execute("UPDATE devices SET config_id=%s WHERE id=%s", config, row["id"])
+    else:
+        await execute(
+            "INSERT INTO devices (user_id, label, config_id, status) VALUES (%s,%s,%s,%s)",
+            user_id,
+            label,
+            config,
+            "active",
+        )
 
 
-def is_banned(user_id: int) -> bool:
-    return get_user(user_id).get("banned", False)
+async def peers_count(tg_user_id: int) -> int:
+    """Return number of active devices linked to the user."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+    row = await fetchone(
+        "SELECT COUNT(*) AS cnt FROM devices WHERE user_id=%s AND status='active'",
+        user_id,
+    )
+    return int(row["cnt"]) if row else 0
 
 
-def update_expiration(user_id: int, minutes: int) -> None:
-    info = get_user(user_id)
-    info["expires_at"] = datetime.utcnow() + timedelta(minutes=minutes)
-    save_user(user_id, info)
+async def update_expiration(tg_user_id: int, minutes: int) -> None:
+    """Extend or create a subscription record for the user."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+    new_expires = dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=minutes)
+
+    sub_row = await fetchone(
+        """
+        SELECT id
+        FROM subscriptions
+        WHERE user_id=%s AND status='active'
+        ORDER BY expires_at DESC
+        LIMIT 1
+        """,
+        user_id,
+    )
+
+    if sub_row:
+        await execute("UPDATE subscriptions SET expires_at=%s WHERE id=%s", new_expires, sub_row["id"])
+    else:
+        await execute(
+            "INSERT INTO subscriptions (user_id, plan, status, expires_at) VALUES (%s,%s,%s,%s)",
+            user_id,
+            "trial",
+            "active",
+            new_expires,
+        )
 
 
-def all_user_ids() -> list[int]:
-    """Return list of all known user IDs."""
-    data = _load()
-    return [int(uid) for uid in data.keys()]
+async def set_ban_status(tg_user_id: int, banned: bool) -> None:
+    """Update ban flag for the user."""
+
+    user_id = await _ensure_user_record(tg_user_id)
+    await execute("UPDATE users SET is_banned=%s WHERE id=%s", banned, user_id)
+
+
+async def is_banned(tg_user_id: int) -> bool:
+    """Return ban status for the user."""
+
+    row = await fetchone("SELECT is_banned FROM users WHERE tg_user_id=%s", tg_user_id)
+    return bool(row and row.get("is_banned"))
+
+
+async def all_user_ids(banned: bool | None = None) -> List[int]:
+    """Return Telegram IDs of all users, optionally filtering by ban status."""
+
+    if banned is None:
+        rows = await fetchall("SELECT tg_user_id FROM users ORDER BY tg_user_id")
+    else:
+        rows = await fetchall(
+            "SELECT tg_user_id FROM users WHERE is_banned=%s ORDER BY tg_user_id",
+            banned,
+        )
+    return [int(row["tg_user_id"]) for row in rows]

--- a/vpn/wireguard.py
+++ b/vpn/wireguard.py
@@ -1,11 +1,12 @@
 import logging
 
-from utils.storage import peers_count, increment_peers
+from utils.storage import peers_count
 
 
-def generate_peer(user_id: int) -> str:
+async def generate_peer(user_id: int) -> str:
     """Return sample WireGuard config and store peer count."""
-    if peers_count(user_id) >= 5:
+
+    if await peers_count(user_id) >= 5:
         raise RuntimeError("Maximum number of peers reached (5)")
     logging.info("Generating WireGuard config for %s", user_id)
     config = (
@@ -28,5 +29,4 @@ def generate_peer(user_id: int) -> str:
         "AllowedIPs = 0.0.0.0/0\n"
         "Endpoint = 188.253.24.141:51822"
     )
-    increment_peers(user_id)
     return config


### PR DESCRIPTION
## Summary
- replace the JSON storage helpers with async PostgreSQL accessors that create users, persist device configs, and manage subscription expiry
- update user-facing handlers and the WireGuard helper to await the new async API so device limits and configs are stored in the database
- adjust admin broadcast and gift flows to pull user lists from PostgreSQL

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68d5a3ba64c0832eac062d65dd0fdca5