### PR TITLE
Fix device label indexing for repeated device types

### DIFF
--- a/handlers/devices.py
+++ b/handlers/devices.py
@@ -30,7 +30,7 @@ async def _device_limit_info(user_id: int) -> tuple[dict, int, int]:
 
 
 def _next_device_index(devices: Mapping[str, object], base_label: str) -> int:
-    pattern = re.compile(rf"^{re.escape(base_label)}(?: \((?P<index>\\d+)\))?$")
+    pattern = re.compile(rf"^{re.escape(base_label)}(?: \((?P<index>\d+)\))?$")
     max_index = 0
     for label in devices.keys():
         match = pattern.match(label)


### PR DESCRIPTION
## Summary
- correct the device label regex so numbered variants such as "Компьютер (3)" are detected
- ensure subsequent device additions receive incrementing suffixes instead of repeating "(2)"

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d98e4da9e8832e88f841323633c628