### PR TITLE
Adjust PC instruction keyboard layout

### DIFF
--- a/keyboards/main.py
+++ b/keyboards/main.py
@@ -100,11 +100,13 @@ def get_pc_instructions_keyboard() -> InlineKeyboardMarkup:
         [
             InlineKeyboardButton(
                 text="🔴 Инструкция для Windows", callback_data="instruction_windows"
-            ),
+            )
+        ],
+        [
             InlineKeyboardButton(
                 text="🟢 Инструкция для MacOS", callback_data="instruction_macos"
-            ),
-        ]
+            )
+        ],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 


### PR DESCRIPTION
## Summary
- place the Windows and MacOS instruction buttons for PC guides on separate rows to match other instruction keyboards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabf12d5b4832e966e95a1b03b0e5b