### PR TITLE
Add localization system and translations

### DIFF
--- a/handlers/referral.py
+++ b/handlers/referral.py
@@ -1,23 +1,33 @@
 import logging
-from aiogram import Router, types, F
+
+from aiogram import F, Router, types
 from aiogram.fsm.context import FSMContext
 
 from keyboards.main import get_share_keyboard
 from states.states import MenuState
+from utils.storage import get_user_locale
+from utils.texts import get_all_translations, t
 
 router = Router()
 
 
-@router.message(MenuState.main_menu, F.text == "🤝 Пригласить друга")
+async def _resolve_locale(state: FSMContext, user_id: int) -> str:
+    data = await state.get_data()
+    locale = data.get("locale")
+    if locale:
+        return locale
+    locale = await get_user_locale(user_id)
+    await state.update_data(locale=locale)
+    return locale
+
+
+@router.message(MenuState.main_menu, F.text.in_(get_all_translations("btn_invite_friend")))
 async def referral_start(message: types.Message, state: FSMContext) -> None:
+    locale = await _resolve_locale(state, message.from_user.id)
     bot_username = (await message.bot.get_me()).username
     ref_link = f"https://t.me/{bot_username}?start={message.from_user.id}"
     await message.answer(
-        (
-            "🤝 Приглашай друзей — получай дни в подарок.\n\n"
-            "За каждого подключившегося по твоей ссылке получи +7 дней к твоей подписке.\n\n"
-            "Поделись ссылкой и пользуйся дольше — бесплатно."
-        ),
-        reply_markup=get_share_keyboard(ref_link),
+        t("referral_intro", locale),
+        reply_markup=get_share_keyboard(ref_link, locale),
     )
     logging.info("Referral link sent to %s", message.from_user.id)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,19 +1,22 @@
 import logging
-from aiogram import Router, types, F
+from datetime import datetime, timedelta
+
+from aiogram import F, Router, types
 from aiogram.filters import CommandStart
 from aiogram.fsm.context import FSMContext
 
-from datetime import datetime, timedelta
-
-from keyboards.main import (
-    get_intro_keyboard,
-    get_main_keyboard,
-)
+from keyboards.main import get_intro_keyboard, get_main_keyboard
 from states.states import MenuState
-from utils.userdata import get_user_info, format_timedelta
-from utils.storage import register_referral, update_expiration, grant_trial_if_new
-from utils.plans import get_plan_title, get_plan_limit
-from utils.texts import t
+from utils.plans import get_plan_limit, get_plan_title
+from utils.storage import (
+    get_user_locale,
+    grant_trial_if_new,
+    register_referral,
+    set_user_locale,
+    update_expiration,
+)
+from utils.texts import get_all_translations, normalize_locale, t
+from utils.userdata import format_timedelta, get_user_info
 
 REFERRAL_REWARD_MINUTES = 7 * 24 * 60
 TRIAL_PERIOD_MINUTES = 7 * 24 * 60
@@ -25,18 +28,20 @@ router = Router()
 async def command_start(message: types.Message, state: FSMContext) -> None:
     await _process_referral(message)
 
+    language_code = message.from_user.language_code
+    normalized_locale = normalize_locale(language_code)
+    await set_user_locale(message.from_user.id, language_code)
+    await state.update_data(locale=normalized_locale)
+
     trial_granted = await grant_trial_if_new(message.from_user.id, TRIAL_PERIOD_MINUTES)
     if trial_granted:
-        await message.answer(
-            "🎁 Твой бонус: 7 дней бесплатно!\n"
-            "Попробуй быстрый и защищённый доступ без ограничений."
-        )
+        await message.answer(t("start_trial_granted", normalized_locale))
 
     data = await state.get_data()
     if not data.get("seen_intro"):
         await message.answer(
-            t("start_pitch"),
-            reply_markup=get_intro_keyboard(),
+            t("start_pitch", normalized_locale),
+            reply_markup=get_intro_keyboard(normalized_locale),
         )
         await state.update_data(seen_intro=True)
         await state.set_state(MenuState.intro)
@@ -51,14 +56,17 @@ async def show_menu_after_intro(message: types.Message, state: FSMContext) -> No
 
 async def show_main_menu(message: types.Message, state: FSMContext) -> None:
     info = await get_user_info(message.from_user.id)
+    locale = info.get("locale") or (await state.get_data()).get("locale") or "en"
+    await state.update_data(locale=locale)
     devices = info.get("devices", {})
     expires = info.get("expires_at")
     time_left = (expires - datetime.utcnow()) if expires else timedelta()
     active_for = (
-        format_timedelta(time_left)
+        format_timedelta(time_left, locale)
         if time_left.total_seconds() > 0
-        else "0 секунд"
+        else t("time_zero", locale)
     )
+
     def normalize_device_name(name: str) -> str:
         trimmed = name.lstrip()
         while trimmed and not trimmed[0].isalnum():
@@ -66,29 +74,45 @@ async def show_main_menu(message: types.Message, state: FSMContext) -> None:
         return trimmed or name
 
     plan_value = info.get("plan")
-    plan_title = get_plan_title(plan_value)
+    plan_title = get_plan_title(plan_value, locale)
     device_limit = info.get("device_limit") or get_plan_limit(plan_value)
     connected_devices = len(devices)
-    devices_counter = f"(Устройства: {connected_devices} / {device_limit})"
+    devices_counter = t("status_devices_counter", locale).format(
+        connected=connected_devices,
+        limit=device_limit,
+    )
 
     if devices:
         device_lines = "\n".join(
-            f"- {normalize_device_name(device_name)}" for device_name in devices.keys()
+            t("status_connections_prefix", locale).format(
+                device_name=normalize_device_name(device_name)
+            )
+            for device_name in devices.keys()
         )
-        connections_block = f"📟 Подключения:\n{device_lines}"
+        connections_block = (
+            t("status_connections_header", locale) + "\n" + device_lines
+        )
     else:
-        connections_block = "📟 Подключения:\nНет подключений"
+        connections_block = (
+            t("status_connections_header", locale)
+            + "\n"
+            + t("status_connections_empty", locale)
+        )
 
-    status_text = t("status_text").format(
-        connections_block=connections_block,
-        active_for=active_for,
-        plan_title=plan_title,
-        devices_counter=devices_counter,
-    )
-    await message.answer(
-        status_text,
-        reply_markup=get_main_keyboard(),
-    )
+    status_lines = [
+        t("status_header", locale),
+        "",
+        t("status_plan_line", locale).format(plan_title=plan_title),
+        devices_counter,
+        "",
+        connections_block,
+        "",
+        t("status_active_line", locale).format(duration=active_for),
+        "",
+        t("status_bonus_line", locale),
+    ]
+    status_text = "\n".join(status_lines)
+    await message.answer(status_text, reply_markup=get_main_keyboard(locale))
     await state.set_state(MenuState.main_menu)
 
 
@@ -131,9 +155,10 @@ async def _process_referral(message: types.Message) -> None:
         return
 
     try:
+        locale = await get_user_locale(referrer_id)
         await message.bot.send_message(
             referrer_id,
-            "🎉 Ваш друг присоединился!\nВам начислено +7 дней к подписке ✨",
+            t("referral_reward_notification", locale),
         )
     except Exception as exc:  # noqa: BLE001
         logging.exception("Failed to notify referrer %s: %s", referrer_id, exc)
@@ -141,7 +166,7 @@ async def _process_referral(message: types.Message) -> None:
         logging.info("Referral reward granted to %s by %s", referrer_id, new_user_id)
 
 
-@router.message(F.text == t("btn_main_menu"))
+@router.message(F.text.in_(get_all_translations("btn_main_menu")))
 async def main_menu_button(message: types.Message, state: FSMContext) -> None:
     await show_main_menu(message, state)
 
@@ -151,6 +176,6 @@ async def main_menu_callback(callback: types.CallbackQuery, state: FSMContext) -
     await callback.answer()
     try:
         await callback.message.delete()
-    except Exception as e:  # noqa: BLE001
-        logging.exception("Failed to delete message: %s", e)
+    except Exception as exc:  # noqa: BLE001
+        logging.exception("Failed to delete message: %s", exc)
     await show_main_menu(callback.message, state)

--- a/keyboards/main.py
+++ b/keyboards/main.py
@@ -1,122 +1,145 @@
+from urllib.parse import quote_plus
+
 from aiogram.types import (
-    ReplyKeyboardMarkup,
-    KeyboardButton,
-    InlineKeyboardMarkup,
     InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
 )
+
+from utils.subscription_plans import SUBSCRIPTION_PLANS
 from utils.texts import t
 
 
-def get_intro_keyboard() -> ReplyKeyboardMarkup:
-    keyboard = [[KeyboardButton(text="🚀 Вперед!")]]
+def get_intro_keyboard(locale: str) -> ReplyKeyboardMarkup:
+    keyboard = [[KeyboardButton(text=t("btn_intro_continue", locale))]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def get_main_keyboard() -> ReplyKeyboardMarkup:
+def get_main_keyboard(locale: str) -> ReplyKeyboardMarkup:
     keyboard = [
-        [KeyboardButton(text=t("btn_devices")), KeyboardButton(text=t("btn_subscription"))],
-        [KeyboardButton(text="🤝 Пригласить друга"), KeyboardButton(text=t("btn_questions"))],
-        [KeyboardButton(text=t("btn_main_menu"))],
-    ]
-    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
-
-
-def get_devices_keyboard() -> ReplyKeyboardMarkup:
-    keyboard = [
-        [KeyboardButton(text="📱 Телефон"), KeyboardButton(text="💻 Компьютер")],
-        [KeyboardButton(text="🔌 Мои устройства"), KeyboardButton(text="⬅️ Назад")],
-    ]
-    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
-
-
-def get_subscription_plan_keyboard() -> ReplyKeyboardMarkup:
-    keyboard = [
-        [KeyboardButton(text="💫 Устройства: 2 - 99₽/мес.")],
-        [KeyboardButton(text="✨ Устройства: 5 - 169₽/мес.")],
-        [KeyboardButton(text="⬅️ Назад")],
-    ]
-    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
-
-
-def get_subscription_duration_keyboard(plan_key: str) -> ReplyKeyboardMarkup:
-    plan_options = {
-        "devices_2": [
-            "1 месяц - 99₽",
-            "🔹3 месяца - 249₽",
-            "🔸6 месяцев - 399₽",
+        [
+            KeyboardButton(text=t("btn_devices", locale)),
+            KeyboardButton(text=t("btn_subscription", locale)),
         ],
-        "devices_5": [
-            "1 месяц - 169₽",
-            "🔹3 месяца - 449₽",
-            "🔸6 месяцев - 749₽",
+        [
+            KeyboardButton(text=t("btn_invite_friend", locale)),
+            KeyboardButton(text=t("btn_questions", locale)),
         ],
-    }
-    options = plan_options.get(plan_key, [])
-    keyboard = [
-        [KeyboardButton(text=options[0]), KeyboardButton(text=options[1])],
-        [KeyboardButton(text=options[2])],
-        [KeyboardButton(text="⬅️ Назад")],
-    ] if len(options) == 3 else [[KeyboardButton(text="⬅️ Назад")]]
+        [KeyboardButton(text=t("btn_main_menu", locale))],
+    ]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def get_payment_methods_keyboard() -> InlineKeyboardMarkup:
+def get_devices_keyboard(locale: str) -> ReplyKeyboardMarkup:
     keyboard = [
-        [InlineKeyboardButton(text="💳 Банковская карта", callback_data="pay_card")],
+        [
+            KeyboardButton(text=t("btn_phone", locale)),
+            KeyboardButton(text=t("btn_computer", locale)),
+        ],
+        [
+            KeyboardButton(text=t("btn_my_devices", locale)),
+            KeyboardButton(text=t("btn_back", locale)),
+        ],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_subscription_plan_keyboard(locale: str) -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text=t(config["button_key"], locale))]
+        for config in SUBSCRIPTION_PLANS.values()
+    ]
+    keyboard.append([KeyboardButton(text=t("btn_back", locale))])
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_subscription_duration_keyboard(plan_key: str, locale: str) -> ReplyKeyboardMarkup:
+    plan_config = SUBSCRIPTION_PLANS.get(plan_key, {})
+    durations = [
+        t(duration_key, locale)
+        for duration_key, _ in plan_config.get("durations", ())  # type: ignore[call-arg]
+    ]
+    keyboard: list[list[KeyboardButton]] = []
+    if len(durations) >= 2:
+        keyboard.append(
+            [KeyboardButton(text=durations[0]), KeyboardButton(text=durations[1])]
+        )
+        remaining = durations[2:]
+    else:
+        remaining = durations
+    for label in remaining:
+        keyboard.append([KeyboardButton(text=label)])
+    keyboard.append([KeyboardButton(text=t("btn_back", locale))])
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_payment_methods_keyboard(locale: str) -> InlineKeyboardMarkup:
+    keyboard = [
+        [InlineKeyboardButton(text=t("btn_pay_card", locale), callback_data="pay_card")]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-def get_payment_navigation_keyboard() -> ReplyKeyboardMarkup:
+def get_payment_navigation_keyboard(locale: str) -> ReplyKeyboardMarkup:
     keyboard = [
-        [KeyboardButton(text=t("btn_main_menu"))],
-        [KeyboardButton(text="⬅️ Назад")],
+        [KeyboardButton(text=t("btn_main_menu", locale))],
+        [KeyboardButton(text=t("btn_back", locale))],
     ]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
-from urllib.parse import quote_plus
 
 
-def get_share_keyboard(url: str) -> InlineKeyboardMarkup:
+def get_share_keyboard(url: str, locale: str) -> InlineKeyboardMarkup:
     share_url = f"https://t.me/share/url?url={quote_plus(url)}"
-    keyboard = [[InlineKeyboardButton(text="Поделиться ссылкой", url=share_url)]]
+    keyboard = [[InlineKeyboardButton(text=t("btn_share_link", locale), url=share_url)]]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-def get_main_menu_only_keyboard() -> ReplyKeyboardMarkup:
-    keyboard = [[KeyboardButton(text=t("btn_main_menu"))]]
+def get_main_menu_only_keyboard(locale: str) -> ReplyKeyboardMarkup:
+    keyboard = [[KeyboardButton(text=t("btn_main_menu", locale))]]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def get_phone_instructions_keyboard() -> InlineKeyboardMarkup:
-    keyboard = [
-        [InlineKeyboardButton(text=t("btn_android"), callback_data="instruction_android")],
-        [InlineKeyboardButton(text=t("btn_ios"), callback_data="instruction_ios")],
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=keyboard)
-
-
-def get_pc_instructions_keyboard() -> InlineKeyboardMarkup:
+def get_phone_instructions_keyboard(locale: str) -> InlineKeyboardMarkup:
     keyboard = [
         [
             InlineKeyboardButton(
-                text="🔴 Инструкция для Windows", callback_data="instruction_windows"
+                text=t("btn_android", locale), callback_data="instruction_android"
             )
         ],
         [
             InlineKeyboardButton(
-                text="🟢 Инструкция для MacOS", callback_data="instruction_macos"
+                text=t("btn_ios", locale), callback_data="instruction_ios"
             )
         ],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-def get_my_devices_keyboard(devices: list[str]) -> ReplyKeyboardMarkup:
+def get_pc_instructions_keyboard(locale: str) -> InlineKeyboardMarkup:
+    keyboard = [
+        [
+            InlineKeyboardButton(
+                text=t("btn_windows_instructions", locale),
+                callback_data="instruction_windows",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                text=t("btn_macos_instructions", locale),
+                callback_data="instruction_macos",
+            )
+        ],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_my_devices_keyboard(devices: list[str], locale: str) -> ReplyKeyboardMarkup:
     keyboard = [[KeyboardButton(text=name)] for name in devices]
-    keyboard.append([KeyboardButton(text="⬅️ Назад")])
+    keyboard.append([KeyboardButton(text=t("btn_back", locale))])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def get_main_menu_inline() -> InlineKeyboardMarkup:
-    keyboard = [[InlineKeyboardButton(text=t("btn_main_menu"), callback_data="main_menu")]]
+def get_main_menu_inline(locale: str) -> InlineKeyboardMarkup:
+    keyboard = [[InlineKeyboardButton(text=t("btn_main_menu", locale), callback_data="main_menu")]]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)

--- a/utils/plans.py
+++ b/utils/plans.py
@@ -1,20 +1,17 @@
-"""Plan configuration helpers."""
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class PlanConfig:
-    title: str
+    title_key: str
     device_limit: int
 
 
 _PLAN_DEFAULT_KEY = "trial"
 _PLAN_CONFIGS: dict[str, PlanConfig] = {
-    "trial": PlanConfig(title="Бесплатный период", device_limit=2),
-    "device2": PlanConfig(title="2 устройств(-а)", device_limit=2),
-    "device5": PlanConfig(title="5 устройств(-а)", device_limit=5),
+    "trial": PlanConfig(title_key="plan_title_trial", device_limit=2),
+    "device2": PlanConfig(title_key="plan_title_device2", device_limit=2),
+    "device5": PlanConfig(title_key="plan_title_device5", device_limit=5),
 }
 
 
@@ -33,8 +30,14 @@ def get_plan_config(plan: str | None) -> PlanConfig:
     return _PLAN_CONFIGS[key]
 
 
-def get_plan_title(plan: str | None) -> str:
-    return get_plan_config(plan).title
+def get_plan_title_key(plan: str | None) -> str:
+    return get_plan_config(plan).title_key
+
+
+def get_plan_title(plan: str | None, locale: str | None = None) -> str:
+    from utils.texts import t
+
+    return t(get_plan_title_key(plan), locale)
 
 
 def get_plan_limit(plan: str | None) -> int:

--- a/utils/subscription_plans.py
+++ b/utils/subscription_plans.py
@@ -1,0 +1,20 @@
+SUBSCRIPTION_PLANS: dict[str, dict[str, object]] = {
+    "devices_2": {
+        "button_key": "plan_devices_2_button",
+        "title_key": "plan_devices_2_title",
+        "durations": (
+            ("plan_devices_2_duration_1m", 99_00),
+            ("plan_devices_2_duration_3m", 249_00),
+            ("plan_devices_2_duration_6m", 399_00),
+        ),
+    },
+    "devices_5": {
+        "button_key": "plan_devices_5_button",
+        "title_key": "plan_devices_5_title",
+        "durations": (
+            ("plan_devices_5_duration_1m", 169_00),
+            ("plan_devices_5_duration_3m", 449_00),
+            ("plan_devices_5_duration_6m", 749_00),
+        ),
+    },
+}

--- a/utils/texts.py
+++ b/utils/texts.py
@@ -1,75 +1,252 @@
-from typing import Dict
+from __future__ import annotations
 
-TEXTS: Dict[str, str] = {
-    # /start and main pitch
-    "start_pitch": (
-        "🚀 Удобный сервис прямо в Telegram.\n"
-        "Подключайся и пользуйся интернетом без лишних ограничений!"
-    ),
+from typing import Dict, Set
 
-    # dashboard / status
-    "status_text": (
-        "👋 Ваши устройства и статус доступа\n\n"
-        "Здесь можно узнать какие устройства у тебя подключены и статус подписки.\n\n"
-        "📦 Ваш план: {plan_title}\n"
-        "{devices_counter}\n\n"
-        "{connections_block}\n\n"
-        "⏱️Подписка активна: {active_for}\n\n"
-        "🎁 Бонус: +7 дней за каждого приглашённого друга"
-    ),
+SUPPORTED_LOCALES = [
+    "en",
+    "ru",
+    "ar",
+    "be",
+    "ca",
+    "hr",
+    "cs",
+    "nl",
+    "fi",
+    "fr",
+    "de",
+    "he",
+    "hu",
+    "id",
+    "it",
+    "kk",
+    "ko",
+    "ms",
+    "no",
+    "fa",
+    "pl",
+    "pt-br",
+    "ro",
+    "sr",
+    "sk",
+    "es",
+    "sv",
+    "tr",
+    "uk",
+    "uz",
+    "vi",
+]
 
-    # subscription screen
-    "subscription_intro": (
-        "✨ Что даёт подписка:\n"
-        "• Быстрый и защищённый доступ к твоим сервисам!\n"
-        "• Никакой рекламы и отвлекающих элементов.\n"
-        "• Минимальная цена — всего 99₽ в месяц!🔥\n\n"
-        "👉 Выбирай план: для 2 или 5 устройств одновременно."
-    ),
-
-    # devices flow
-    "devices_choose": "📲 Выбери устройство, которое хочешь подключить.\n(Это займёт всего пару минут — всё просто!)",
-    "device_ready_title": "🧩 Подключение почти готово!",
-    "device_ready_body": (
-        "Выбери удобный способ:\n"
-        "1. Скачать файл профиля и импортировать в AmneziaWG / WireGuard\n"
-        "2. Отсканировать QR-код прямо в приложении\n\n"
-        "📚 Выбери подходящую инструкцию и подключись за пару шагов.\n\n"
-        "⚠️ Один профиль можно использовать только на одном устройстве!"
-    ),
-    "devices_pick_guide": (
-        "📖 Ниже есть инструкции для разных устройств — выбери свою ОС и следуй шагам."
-    ),
-    "devices_none": (
-        "У тебя пока нет подключённых устройств!\n"
-        "📲 Для подключения выбери одно из двух: Телефон / Компьютер"
-    ),
-    "devices_limit_reached": "Достигнут лимит подключений на этом тарифе.",
-
-    # faq
-    "faq_title": "❓ Что, как и почему?",
-    "faq_body": (
-        "Мы собрали частые вопросы в одной статье.\n"
-        "📖 ЧаВо: {faq_url}\n\n"
-        "Ваш ID для обращения: {tg_id}\n\n"
-        "🗺 Есть вопросы? Напишите нам: @{support_handle}"
-    ),
-
-    # generic / buttons
-    "btn_main_menu": "🏠 Главное меню",
-    "btn_android": "🔴 Инструкция для Android",
-    "btn_ios": "🟢 Инструкция для iPhone",
-    "btn_devices": "📱 Устройства",
-    "btn_subscription": "💎 Подписка",
-    "btn_questions": "❓ Вопросы",
-
-    # referral
-    "ref_invite_title": "🤝 Приглашай друзей — получай дни в подарок.",
-    "ref_invite_body": (
-        "За каждого подключившегося по твоей ссылке получи +7 дней к подписке.\n"
-        "Поделись ссылкой и пользуйся дольше — бесплатно."
-    ),
+TEXTS: Dict[str, Dict[str, str]] = {
+    "en": {
+        "start_pitch": "🚀 Fast and easy access in Telegram.\nStay private, stable, and fast wherever you are.",
+        "start_trial_granted": "🎁 Your bonus: 7 days for free!\nEnjoy fast and secure access without limits.",
+        "status_header": "👋 <b>Here is information about your devices and subscription</b>",
+        "status_plan_line": "📦 <b>Your plan:</b> {plan_title}",
+        "status_devices_counter": "(<b>Devices:</b> {connected} / {limit})",
+        "status_connections_header": "📟 <b>Connections</b>",
+        "status_connections_empty": "No connected devices yet",
+        "status_active_line": "🕒 <b>Subscription active:</b> {duration}",
+        "status_bonus_line": "🎁 <b>Bonus:</b> +7 days for every invited friend!",
+        "status_connections_prefix": "- {device_name}",
+        "time_zero": "0 seconds",
+        "time_day_forms": "day|days|days",
+        "time_hour_forms": "hour|hours|hours",
+        "time_minute_forms": "minute|minutes|minutes",
+        "time_second_forms": "second|seconds|seconds",
+        "btn_intro_continue": "🚀 Let's go!",
+        "btn_devices": "📟 Devices",
+        "btn_subscription": "🔒 Subscription",
+        "btn_invite_friend": "🤝 Invite a friend",
+        "btn_questions": "❓ FAQ & Support",
+        "btn_main_menu": "🏠 Main menu",
+        "btn_back": "⬅️ Back",
+        "btn_phone": "📱 Phone",
+        "btn_computer": "💻 Computer",
+        "btn_my_devices": "🔌 My devices",
+        "btn_android": "📚 Android guide",
+        "btn_ios": "📚 iPhone guide",
+        "btn_windows_instructions": "🔴 Windows guide",
+        "btn_macos_instructions": "🟢 macOS guide",
+        "btn_share_link": "Share the link",
+        "btn_pay_card": "💳 Bank card",
+        "devices_choose": "Choose how you want to connect:",
+        "devices_generation_in_progress": "⏳ Configuration is already being generated. Please wait for the file/QR.",
+        "devices_limit_reached": "⚠️ Device limit reached. Remove one before adding a new device.",
+        "device_ready_title": "✅ Configuration is ready!",
+        "device_ready_body": "Scan the QR code or download the config file to connect.",
+        "devices_pick_guide": "Need instructions? Choose your platform:",
+        "devices_none": "You have no connected devices yet.",
+        "devices_list_intro": "👇 Your connected devices:",
+        "devices_select_prompt": "Please choose a device from the list.",
+        "device_default_name": "Device {index}",
+        "instruction_link_android": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Guide for Android</a>",
+        "instruction_link_ios": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Guide for iPhone</a>",
+        "instruction_link_windows": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Guide for Windows</a>",
+        "instruction_link_macos": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Guide for macOS</a>",
+        "subscription_intro": "Choose how many devices you want to connect:",
+        "subscription_duration_prompt": "⏱️ Choose subscription duration:\n{options}",
+        "subscription_duration_hint": "💡 Longer periods are cheaper per month.",
+        "subscription_payment_thanks": (
+            "🫶 Thank you for your trust!\n\n"
+            "You are one step closer to a secure, stable, and fast internet.\n"
+            "We made the process as convenient as possible.\n\n"
+            "👇 Pick a payment method:"
+        ),
+        "subscription_payment_change": "🔁 Want to change the plan? Use the buttons below before paying.",
+        "subscription_invalid_plan": "Please choose one of the available plans.",
+        "subscription_invalid_duration": "Please choose one of the suggested durations.",
+        "subscription_payment_created": "Payment created (mock)",
+        "plan_devices_2_button": "💫 Devices: 2 - 99₽/month",
+        "plan_devices_5_button": "✨ Devices: 5 - 169₽/month",
+        "plan_devices_2_title": "2 devices",
+        "plan_devices_5_title": "5 devices",
+        "plan_devices_2_duration_1m": "1 month - 99₽",
+        "plan_devices_2_duration_3m": "🔹3 months - 249₽",
+        "plan_devices_2_duration_6m": "🔸6 months - 399₽",
+        "plan_devices_5_duration_1m": "1 month - 169₽",
+        "plan_devices_5_duration_3m": "🔹3 months - 449₽",
+        "plan_devices_5_duration_6m": "🔸6 months - 749₽",
+        "faq_title": "❓ Frequently asked questions",
+        "faq_body": (
+            "Find answers in our FAQ: {faq_url}\n"
+            "Need help? Write to @{support_handle}.\n"
+            "Your Telegram ID: {tg_id}"
+        ),
+        "referral_intro": (
+            "🤝 Invite friends — get bonus days.\n\n"
+            "Each friend who connects via your link gives you +7 days of subscription.\n\n"
+            "Share the link and enjoy longer — for free."
+        ),
+        "referral_reward_notification": "🎉 Your friend joined!\nYou received +7 days to your subscription ✨",
+        "plan_title_trial": "Trial period",
+        "plan_title_device2": "2 devices",
+        "plan_title_device5": "5 devices",
+    },
+    "ru": {
+        "start_pitch": "🚀 Удобный сервис прямо в Telegram.\nСохраняй приватность и стабильность где угодно.",
+        "start_trial_granted": "🎁 Твой бонус: 7 дней бесплатно!\nПопробуй быстрый и защищённый доступ без ограничений.",
+        "status_header": "👋 <b>Вот информация о твоих устройствах и подписке</b>",
+        "status_plan_line": "📦 <b>Твой план:</b> {plan_title}",
+        "status_devices_counter": "(<b>Устройства:</b> {connected} / {limit})",
+        "status_connections_header": "📟 <b>Подключения</b>",
+        "status_connections_empty": "Пока нет подключений",
+        "status_active_line": "🕒 <b>Подписка активна:</b> {duration}",
+        "status_bonus_line": "🎁 <b>Бонус:</b> +7 дней за каждого приглашённого друга!",
+        "status_connections_prefix": "- {device_name}",
+        "time_zero": "0 секунд",
+        "time_day_forms": "день|дня|дней",
+        "time_hour_forms": "час|часа|часов",
+        "time_minute_forms": "минута|минуты|минут",
+        "time_second_forms": "секунда|секунды|секунд",
+        "btn_intro_continue": "🚀 Вперёд!",
+        "btn_devices": "📟 Устройства",
+        "btn_subscription": "🔒 Подписка",
+        "btn_invite_friend": "🤝 Пригласить друга",
+        "btn_questions": "❓ Вопросы и поддержка",
+        "btn_main_menu": "🏠 Главное меню",
+        "btn_back": "⬅️ Назад",
+        "btn_phone": "📱 Телефон",
+        "btn_computer": "💻 Компьютер",
+        "btn_my_devices": "🔌 Мои устройства",
+        "btn_android": "📚 Инструкция для Android",
+        "btn_ios": "📚 Инструкция для iPhone",
+        "btn_windows_instructions": "🔴 Инструкция для Windows",
+        "btn_macos_instructions": "🟢 Инструкция для macOS",
+        "btn_share_link": "Поделиться ссылкой",
+        "btn_pay_card": "💳 Банковская карта",
+        "devices_choose": "Выбери, как хочешь подключиться:",
+        "devices_generation_in_progress": "⏳ Конфиг уже генерируется. Дождись файла или QR-кода.",
+        "devices_limit_reached": "⚠️ Достигнут лимит устройств. Удали одно, чтобы добавить новое.",
+        "device_ready_title": "✅ Конфигурация готова!",
+        "device_ready_body": "Отсканируй QR-код или скачай конфиг, чтобы подключиться.",
+        "devices_pick_guide": "Нужна инструкция? Выбери платформу:",
+        "devices_none": "У тебя ещё нет подключённых устройств.",
+        "devices_list_intro": "👇 Список твоих подключённых устройств:",
+        "devices_select_prompt": "Пожалуйста, выбери устройство из списка.",
+        "device_default_name": "Устройство {index}",
+        "instruction_link_android": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для Android</a>",
+        "instruction_link_ios": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для iPhone</a>",
+        "instruction_link_windows": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для Windows</a>",
+        "instruction_link_macos": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для macOS</a>",
+        "subscription_intro": "Выбери, сколько устройств хочешь подключить:",
+        "subscription_duration_prompt": "⏱️Выбери срок подписки:\n{options}",
+        "subscription_duration_hint": "💡 Стоимость ниже при оплате за больший срок.",
+        "subscription_payment_thanks": (
+            "🫶 Спасибо за доверие!\n\n"
+            "Ты на шаг ближе к безопасному, стабильному и быстрому интернету.\n"
+            "Мы постарались сделать процесс максимально удобным.\n\n"
+            "👇 Выбери подходящий способ оплаты:"
+        ),
+        "subscription_payment_change": "🔁 Чтобы изменить тариф до оплаты, воспользуйся кнопками ниже.",
+        "subscription_invalid_plan": "Выбери один из доступных планов.",
+        "subscription_invalid_duration": "Пожалуйста, выбери один из предложенных тарифов.",
+        "subscription_payment_created": "Оплата создана (мок)",
+        "plan_devices_2_button": "💫 Устройства: 2 - 99₽/мес.",
+        "plan_devices_5_button": "✨ Устройства: 5 - 169₽/мес.",
+        "plan_devices_2_title": "2 устройства",
+        "plan_devices_5_title": "5 устройств",
+        "plan_devices_2_duration_1m": "1 месяц - 99₽",
+        "plan_devices_2_duration_3m": "🔹3 месяца - 249₽",
+        "plan_devices_2_duration_6m": "🔸6 месяцев - 399₽",
+        "plan_devices_5_duration_1m": "1 месяц - 169₽",
+        "plan_devices_5_duration_3m": "🔹3 месяца - 449₽",
+        "plan_devices_5_duration_6m": "🔸6 месяцев - 749₽",
+        "faq_title": "❓ Частые вопросы",
+        "faq_body": (
+            "Ответы ищи в FAQ: {faq_url}\n"
+            "Нужна помощь? Напиши @{support_handle}.\n"
+            "Твой Telegram ID: {tg_id}"
+        ),
+        "referral_intro": (
+            "🤝 Приглашай друзей — получай дни в подарок.\n\n"
+            "За каждого подключившегося по твоей ссылке получи +7 дней к подписке.\n\n"
+            "Поделись ссылкой и пользуйся дольше — бесплатно."
+        ),
+        "referral_reward_notification": "🎉 Ваш друг присоединился!\nВам начислено +7 дней к подписке ✨",
+        "plan_title_trial": "Бесплатный период",
+        "plan_title_device2": "2 устройства",
+        "plan_title_device5": "5 устройств",
+    },
 }
 
-def t(key: str) -> str:
-    return TEXTS[key]
+for locale in SUPPORTED_LOCALES:
+    TEXTS.setdefault(locale, {})
+
+
+def normalize_locale(locale: str | None) -> str:
+    if not locale:
+        return "en"
+    normalized = locale.lower().split("-")[0]
+    if normalized in TEXTS:
+        return normalized
+    # handle Portuguese (Brazil)
+    if normalized == "pt" and locale.lower() in ("pt-br", "pt_br"):
+        return "pt-br"
+    return "en"
+
+
+def t(key: str, locale: str | None = None) -> str:
+    language = normalize_locale(locale)
+    translations = TEXTS.get(language, TEXTS["en"])
+    if key in translations:
+        value = translations[key]
+        if value:
+            return value
+    fallback = TEXTS["en"].get(key)
+    if fallback:
+        return fallback
+    return key
+
+
+def get_all_translations(key: str) -> Set[str]:
+    values: Set[str] = set()
+    for translations in TEXTS.values():
+        value = translations.get(key)
+        if value:
+            values.add(value)
+    fallback = TEXTS["en"].get(key)
+    if fallback:
+        values.add(fallback)
+    if not values:
+        values.add(key)
+    return values

--- a/utils/userdata.py
+++ b/utils/userdata.py
@@ -1,13 +1,14 @@
-from datetime import datetime, timedelta
-from typing import Dict, Any
+from datetime import timedelta
+from typing import Any, Dict
 
-from .plans import get_plan_limit, get_plan_title
+from .plans import get_plan_limit
 from .storage import (
     get_user,
     save_device_config,
     touch_user,
     update_expiration,
 )
+from .texts import t
 
 CONFIG_DURATION_MINUTES = 2
 
@@ -38,54 +39,28 @@ def plural(value: int, forms: tuple[str, str, str]) -> str:
     return forms[2]
 
 
-def format_timedelta(td: timedelta) -> str:
+def _get_forms(key: str, locale: str | None) -> tuple[str, str, str]:
+    value = t(key, locale)
+    parts = value.split("|")
+    if len(parts) == 3:
+        return tuple(parts)  # type: ignore[return-value]
+    return (value, value, value)
+
+
+def format_timedelta(td: timedelta, locale: str | None = None) -> str:
     total_seconds = int(td.total_seconds())
     if total_seconds <= 0:
-        return "0 секунд"
+        return t("time_zero", locale)
     days, rem = divmod(total_seconds, 86400)
     hours, rem = divmod(rem, 3600)
     minutes, seconds = divmod(rem, 60)
     parts = []
     if days:
-        parts.append(f"{days} {plural(days, ('день','дня','дней'))}")
+        parts.append(f"{days} {plural(days, _get_forms('time_day_forms', locale))}")
     if hours:
-        parts.append(f"{hours} {plural(hours, ('час','часа','часов'))}")
+        parts.append(f"{hours} {plural(hours, _get_forms('time_hour_forms', locale))}")
     if minutes:
-        parts.append(f"{minutes} {plural(minutes, ('минута','минуты','минут'))}")
+        parts.append(f"{minutes} {plural(minutes, _get_forms('time_minute_forms', locale))}")
     if seconds and not days and not hours:
-        parts.append(f"{seconds} {plural(seconds, ('секунда','секунды','секунд'))}")
+        parts.append(f"{seconds} {plural(seconds, _get_forms('time_second_forms', locale))}")
     return " ".join(parts)
-
-
-async def build_main_menu_text(user_id: int) -> str:
-    info = await get_user_info(user_id)
-    expires = info.get("expires_at")
-    if expires:
-        time_left = expires - datetime.utcnow()
-    else:
-        time_left = timedelta(seconds=0)
-    active = time_left.total_seconds() > 0
-    devices = info.get("devices", {})
-    plan_value = info.get("plan")
-    plan_title = get_plan_title(plan_value)
-    device_limit = info.get("device_limit") or get_plan_limit(plan_value)
-    connected_devices = len(devices)
-    if devices:
-        status_lines = []
-        for name in devices.keys():
-            status = "Подключён" if active else "Не подключён"
-            status_lines.append(f"<b>{name}</b> — {status}")
-        devices_text = "\n".join(status_lines)
-    else:
-        devices_text = "Устройства не подключены"
-    time_text = format_timedelta(time_left) if active else "0 секунд"
-    return (
-        "👋 <b>Вот информация о твоих устройствах и подписке</b>\n\n"
-        "Здесь можно узнать какие устройства у тебя подключены и статус подписки.\n\n"
-        f"📦 <b>Ваш план:</b> {plan_title}\n"
-        f"(<b>Устройства:</b> {connected_devices} / {device_limit})\n\n"
-        "🧾 <b>Статус подключения:</b>\n"
-        f"{devices_text}\n\n"
-        f"🕒 <b>Подписка активна:</b> {time_text}\n\n"
-        "🎁 <b>Бонус:</b> +7 дней за каждого приглашённого друга!"
-    )


### PR DESCRIPTION
## Summary
- introduce a central `TEXTS` dictionary with helper utilities and a new subscription plan config module for translated strings
- update handlers and keyboards to load user locale, persist it on /start, and route all user-facing text through the translation helper with English fallbacks
- add locale-aware keyboards, device flows, and subscription logic plus new helper functions for locale storage

## Testing
- python -m compileall handlers keyboards utils

------
https://chatgpt.com/codex/tasks/task_e_68dad2ebfa14832eb7c696decb59c55e