### PR TITLE
Adjust device ready and subscription texts

### DIFF
--- a/utils/texts.py
+++ b/utils/texts.py
@@ -75,7 +75,7 @@ TEXTS: Dict[str, Dict[str, str]] = {
         ),
         "devices_generation_in_progress": "⏳ Configuration is already being generated. Please wait for the file/QR.",
         "devices_limit_reached": "⚠️ Device limit reached. Remove one before adding a new device.",
-        "device_ready_title": "📱 Phone/💻 Computer",
+        "device_ready_title": "",
         "device_ready_body": (
             "🧩 Setup is almost done!\n\n"
             "Choose how you want to connect:\n"
@@ -201,7 +201,6 @@ TEXTS: Dict[str, Dict[str, str]] = {
         "instruction_link_windows": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для Windows</a>",
         "instruction_link_macos": "<a href=\"https://telegra.ph/Android-Instr-06-25\">📚 Инструкция для macOS</a>",
         "subscription_intro": (
-            "💎 Оформление подписки\n"
             "✨ Что даёт подписка:\n"
             "• Быстрый и защищённый доступ к твоим сервисам!\n"
             "• Никакой рекламы и отвлекающих элементов.\n"


### PR DESCRIPTION
## Summary
- remove the device_ready title icons so only the setup message is shown
- drop the subscription heading line in the Russian subscription intro so it starts with the requested text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deefcaf10c832ebc175761625a172a